### PR TITLE
Not raise "NotRegistered" error

### DIFF
--- a/lib/firebase_messenger/api/notification.rb
+++ b/lib/firebase_messenger/api/notification.rb
@@ -5,7 +5,7 @@ module FirebaseMessenger
         response = conn('send', params).post
         return response.json if ok?(response)
         error = FirebaseMessenger::BaseError.new(200, response.results.to_s)
-        raise error, error.message
+        raise error, error.message unless error.message.to_s.include?('NotRegistered')
       end
     end
   end


### PR DESCRIPTION
Not needed for moment.
Next : catch it and to update device `push_token` on auth